### PR TITLE
Fix verification findings: style, slugs, depersonalization

### DIFF
--- a/hardware/datasheets/COMPONENT_REVIEW.md
+++ b/hardware/datasheets/COMPONENT_REVIEW.md
@@ -1,4 +1,4 @@
-# Component Review — Commercial Release Audit (v0.3)
+# Component Review: Commercial Release Audit (v0.3)
 
 Full design review of all ICs and key components for commercial readiness.
 Conducted March 2026.
@@ -16,7 +16,7 @@ The TPS746-3.3DRV LDO has a maximum input voltage of 6.0V (abs max 6.5V), but th
 **Why it works in testing:** The TPS746 may survive at 8V in benign conditions, but will fail under temperature extremes, production variance, or extended operation. Not acceptable for commercial release.
 
 **Fix:** Drop-in replacement with **TLV76733DRVR** (LCSC C2848334):
-- Same WSON-6 2x2mm footprint — zero PCB changes
+- Same WSON-6 2x2mm footprint, zero PCB changes
 - Input range: 2.5V to **16V** (8V input with 2x margin)
 - Output: 3.3V fixed, **1A** (upgrade from 500mA)
 - Price: $0.10 (comparable to TPS746)
@@ -30,13 +30,13 @@ The TPS746-3.3DRV LDO has a maximum input voltage of 6.0V (abs max 6.5V), but th
 
 **Severity: CRITICAL**
 
-The INA199A1 has a maximum common-mode input of **26V**. A 6S LiPo at full charge is 25.2V — only 0.8V (3%) margin. Inductive switching spikes from MOSFET commutation can easily push the battery rail to 27-28V transiently, exceeding absolute max and risking permanent damage.
+The INA199A1 has a maximum common-mode input of **26V**. A 6S LiPo at full charge is 25.2V: only 0.8V (3%) margin. Inductive switching spikes from MOSFET commutation can easily push the battery rail to 27-28V transiently, exceeding absolute max and risking permanent damage.
 
 **Fix:** Replace INA199A1DCKR with **INA293A2IDBVR** (LCSC C1855797):
-- Common-mode range: **-4V to 110V** (vs 26V — massive margin)
-- Gain: 100V/V (vs 50V/V — better ADC utilization)
-- Offset: ±25µV max (vs ±150µV — 6x improvement)
-- Bandwidth: 1.3 MHz (vs 14 kHz — 93x improvement)
+- Common-mode range: **-4V to 110V** (vs 26V, massive margin)
+- Gain: 100V/V (vs 50V/V, better ADC utilization)
+- Offset: ±25µV max (vs ±150µV, 6x improvement)
+- Bandwidth: 1.3 MHz (vs 14 kHz, 93x improvement)
 - Package: SOT-23-5 (slightly larger than SC-70-6, requires footprint change)
 
 With 0.2mΩ shunt and 100V/V gain:
@@ -55,7 +55,7 @@ With 0.2mΩ shunt and 100V/V gain:
 ## Low / Informational Issues
 
 ### 6. R18 Footprint Mismatch
-R18 (10kΩ NRST pull-up) uses a capacitor footprint (`C_0201_0603Metric`) instead of resistor footprint. Cosmetic/DRC issue — physically works but should be corrected for production DRC cleanliness.
+R18 (10kΩ NRST pull-up) uses a capacitor footprint (`C_0201_0603Metric`) instead of resistor footprint. Cosmetic/DRC issue, physically works but should be corrected for production DRC cleanliness.
 
 ### 7. Ferrite Beads (FB1-FB4) Need Part Assignment
 Currently generic "200mA" ferrite beads with no specific part number or impedance spec. For commercial release, assign a specific part (e.g., 120Ω @ 100MHz, ≥200mA rated). Must be available on LCSC/JLCPCB in 0201 package.
@@ -64,46 +64,46 @@ Currently generic "200mA" ferrite beads with no specific part number or impedanc
 
 ## Components Verified OK
 
-### LMR51420YDDCR Buck Converter — PASS
+### LMR51420YDDCR Buck Converter: PASS
 
 The 0.47µH inductor (XRIM160808SR47MBCD) is 10x smaller than textbook recommendation (4.7µH), but this is a deliberate size optimization that works because:
 - Actual load is only ~500mA (4× MCU + 4× gate driver + misc), well below the 1.4A IC rating
-- Operates in deep DCM (discontinuous conduction mode) — load current (500mA) << ripple/2 (5.25A)
+- Operates in deep DCM (discontinuous conduction mode), load current (500mA) << ripple/2 (5.25A)
 - Output ripple on 8V rail: ~0.52V peak-to-peak (6.5%) at 6S
-- Gate drivers (NSG2065Q) tolerate this easily — VCC stays within 7.48-8.56V, well inside 7-13.5V operating range
+- Gate drivers (NSG2065Q) tolerate this easily, VCC stays within 7.48-8.56V, well inside 7-13.5V operating range
 - LDO PSRR (65dB @ 1MHz) filters 8V ripple to **0.93mV** on the 3.3V MCU rail
 - The 1.6×0.8mm inductor is critical for the compact 20×20mm board layout
 - LMR51420 has cycle-by-cycle current limiting for inductor saturation protection
 
-### NSG2065Q Gate Driver — PASS
+### NSG2065Q Gate Driver: PASS
 
 - VCC at 8V is at recommended minimum, UVLO at 4.5V provides margin
-- 1.2A source / 1.5A sink drive current — adequate for SP40N03GNJ gate charge
+- 1.2A source / 1.5A sink drive current, adequate for SP40N03GNJ gate charge
 - 100nF bootstrap caps provide 8.5x margin over required gate charge
 - 15Ω gate resistors are appropriate for controlled switching
 - 200ns internal dead time prevents shoot-through
 
-### SP40N03GNJ MOSFETs — PASS (with note)
+### SP40N03GNJ MOSFETs: PASS (with note)
 
 - 40V VDS, 75A ID, 2.9mΩ RDS(on) @ 10V VGS
-- Conduction loss per MOSFET at 17.5A RMS: ~0.89W — manageable
-- Gate charge 26nC — well within NSG2065Q driver capability
+- Conduction loss per MOSFET at 17.5A RMS: ~0.89W, manageable
+- Gate charge 26nC, well within NSG2065Q driver capability
 - 3×3mm PDFN-8L package fits the 20×20mm board
 - Proven thermally in hard flight testing
 - Good price and LCSC/JLCPCB availability (C22466709)
 
 **VDS margin note:** At 6S (25.2V), switching transients with ~20nH stray inductance and 35A/50ns di/dt can produce ~14V spikes, pushing VDS to ~39V on a 40V-rated part. This is tight but workable with good PCB layout (short power loops, cap placement close to MOSFETs). The board has been tested extensively at 6S without issues, confirming the layout handles this well. For the 30×30mm variant, consider 60V parts for additional margin.
 
-### 0805 10µF 50V Bulk Capacitors (C440198) — PASS (Keep Current)
+### 0805 10µF 50V Bulk Capacitors (C440198): PASS (Keep Current)
 
 - GRM21BR61H106KE43L (Murata, X5R, 50V) retains ~60-70% capacitance at 25V DC bias → ~6-7µF effective per cap
-- 33 caps × ~6.5µF = ~215µF effective total — adequate, proven in hard flight testing
+- 33 caps × ~6.5µF = ~215µF effective total, adequate, proven in hard flight testing
 - Alternative GCM31CD71H106KE36L (1206 X7T) is NOT available on LCSC/JLCPCB
 - Switching to 1206 would only gain 15-20% more capacitance but requires PCB redesign and 85% more board area per cap
 - X7T vs X5R DC bias performance is nearly identical; package size is the dominant factor
 - Current design validated in field: no bulk electrolytic needed
 
-### HC-1.0-8PWT Connector — NOTED
+### HC-1.0-8PWT Connector: NOTED
 User handling connector standard migration separately (Betaflight 8-pin JST-SH standard).
 
 ---
@@ -111,33 +111,33 @@ User handling connector standard migration separately (Betaflight 8-pin JST-SH s
 ## DOY170N04T MOSFET Evaluation (User Inquiry)
 
 The DOINGTER DOY170N04T (LCSC C50386319) was evaluated as a potential MOSFET upgrade:
-- 40V, 170A, 1.7mΩ RDS(on) @ 10V — significantly lower resistance than SP40N03GNJ (2.9mΩ)
-- Package: TDFN3333-8PL (3.3×3.3mm) — slightly larger than current 3×3mm PDFN-8L
+- 40V, 170A, 1.7mΩ RDS(on) @ 10V, significantly lower resistance than SP40N03GNJ (2.9mΩ)
+- Package: TDFN3333-8PL (3.3×3.3mm), slightly larger than current 3×3mm PDFN-8L
 - Would reduce conduction losses by ~40%
 
 **Assessment:** Not recommended for v0.4:
 - DOINGTER is an unestablished brand with limited track record
-- 3.3×3.3mm package is slightly larger — may not fit current 3×3mm footprint without layout changes
-- Lower RDS(on) means higher gate charge (Qg) — need to verify NSG2065Q can drive 6 of these per channel
+- 3.3×3.3mm package is slightly larger, may not fit current 3×3mm footprint without layout changes
+- Lower RDS(on) means higher gate charge (Qg), need to verify NSG2065Q can drive 6 of these per channel
 - SP40N03GNJ is proven, cheaper, and thermally adequate in testing
 
 ---
 
-## SP40N01GHNK — Candidate for 30×30mm Variant
+## SP40N01GHNK: Candidate for 30×30mm Variant
 
-**Siliup SP40N01GHNK** (LCSC C22385416) — same manufacturer as the SP40N03GNJ, in 5×6mm PDFN-8L.
+**Siliup SP40N01GHNK** (LCSC C22385416), same manufacturer as the SP40N03GNJ, in 5×6mm PDFN-8L.
 
 | Parameter | SP40N03GNJ (20×20) | SP40N01GHNK (30×30 candidate) |
 |-----------|-------------------|-------------------------------|
 | VDS | 40V | 40V |
 | ID (package) | 75A | 120A |
-| ID (silicon) | — | 230A |
+| ID (silicon) | - | 230A |
 | RDS(on) @ 10V | 2.9mΩ | **1.2mΩ typ / 1.5mΩ max** |
-| RDS(on) @ 4.5V | — | ~1.6mΩ (from RDS vs ID curve) |
+| RDS(on) @ 4.5V | - | ~1.6mΩ (from RDS vs ID curve) |
 | Qg | 26nC | **126nC** |
-| Qgd | — | 15.5nC |
-| Ciss | — | 5750pF |
-| Rise / Fall | — | 5ns / 9.5ns |
+| Qgd | - | 15.5nC |
+| Ciss | - | 5750pF |
+| Rise / Fall | - | 5ns / 9.5ns |
 | RθJC | ~2°C/W (est.) | **0.96°C/W** |
 | PD | 55W | **130W** |
 | EAS | not published | **1089mJ** (published!) |
@@ -148,19 +148,19 @@ The DOINGTER DOY170N04T (LCSC C50386319) was evaluated as a potential MOSFET upg
 **Assessment: Strong candidate for 30×30mm variant.**
 
 Pros:
-- Same manufacturer family — proven silicon quality, consistent supply chain
+- Same manufacturer family, proven silicon quality, consistent supply chain
 - 58% lower RDS(on) (1.2mΩ vs 2.9mΩ) → ~58% lower conduction losses
-- Published EAS (1089mJ) — avalanche-rated, unlike the SP40N03GNJ
-- 0.96°C/W RθJC vs ~2°C/W — much better thermal performance
+- Published EAS (1089mJ), avalanche-rated, unlike the SP40N03GNJ
+- 0.96°C/W RθJC vs ~2°C/W, much better thermal performance
 - Comparable price
 
 Cons:
-- Qg is 4.8× higher (126nC vs 26nC) — impacts gate driver loading
+- Qg is 4.8× higher (126nC vs 26nC), impacts gate driver loading
 - JLCPCB assembly availability needs verification
 
 **Gate driver compatibility check:** With 126nC Qg per MOSFET, the NSG2065Q bootstrap cap (100nF) needs to supply enough charge for the high-side MOSFET each PWM cycle. Per high-side MOSFET: 126nC required. Bootstrap cap at 8V: 100nF × 8V = 800nC available. With one high-side MOSFET switching per phase: 800/126 = 6.3× margin. **Still adequate**, though tighter than the SP40N03GNJ (800/26 = 30× margin). Consider increasing bootstrap cap to 220nF for extra margin on the 30×30 variant.
 
-Gate switching with 15Ω gate resistor: peak gate current ≈ (8V - 3V) / 15Ω ≈ 333mA, switching time ≈ 126nC / 333mA ≈ 378ns. This is slower than the SP40N03GNJ (~78ns). For 24kHz PWM (41.7µs period), 378ns is still <1% of the cycle — acceptable. Consider reducing gate resistance to 10Ω on the 30×30 variant if faster switching is desired.
+Gate switching with 15Ω gate resistor: peak gate current ≈ (8V - 3V) / 15Ω ≈ 333mA, switching time ≈ 126nC / 333mA ≈ 378ns. This is slower than the SP40N03GNJ (~78ns). For 24kHz PWM (41.7µs period), 378ns is still <1% of the cycle, acceptable. Consider reducing gate resistance to 10Ω on the 30×30 variant if faster switching is desired.
 
 ---
 

--- a/hardware/flash_openesc20.sh
+++ b/hardware/flash_openesc20.sh
@@ -176,7 +176,7 @@ wait_for_stlink_connect() {
 LOOP_MODE=false
 if [[ "${1:-}" == "--loop" ]]; then
     LOOP_MODE=true
-    echo "Loop mode enabled — swap boards on jig, auto-flashes next."
+    echo "Loop mode enabled: swap boards on jig, auto-flashes next."
     echo ""
 fi
 

--- a/hardware/scripts/v_beta_hygiene_fix.py
+++ b/hardware/scripts/v_beta_hygiene_fix.py
@@ -1,4 +1,4 @@
-"""V-beta hygiene fixes — surgical line-by-line property-value substitutions.
+"""V-beta hygiene fixes: surgical line-by-line property-value substitutions.
 
 Operates on .kicad_sch files in BINARY MODE. Touches only the bytes inside
 property values; never modifies whitespace, line endings, indentation, or
@@ -38,7 +38,7 @@ REF_RE = re.compile(rb'\(property "Reference" "([^"]+)"')
 FP_RE = re.compile(rb'\(property "Footprint" "([^"]+)"')
 
 # Library-cache fence. Inside (lib_symbols ...), property values are template
-# defaults — we leave them alone. They match Reference="C", "R", "U", etc.
+# defaults: we leave them alone. They match Reference="C", "R", "U", etc.
 # Only operate on instance blocks (outside lib_symbols).
 
 
@@ -135,7 +135,7 @@ def process(path: Path, apply: bool) -> int:
     print(f"  newline count preserved:  {orig_nl}->{new_nl}  [{ 'OK' if nl_ok else 'FAIL' }]")
 
     if not (paren_ok and nl_ok):
-        print(f"  ERROR: structural integrity broken — refusing to write.")
+        print(f"  ERROR: structural integrity broken, refusing to write.")
         return 0
 
     if apply and new_data != original:

--- a/hardware/tools/esc_thermal.py
+++ b/hardware/tools/esc_thermal.py
@@ -14,7 +14,7 @@ import argparse
 import math
 
 # ═══════════════════════════════════════════════════════════════
-#  MOSFET profiles — all values from datasheets
+#  MOSFET profiles: all values from datasheets
 # ═══════════════════════════════════════════════════════════════
 
 PROFILES = {
@@ -71,8 +71,8 @@ PROFILES = {
         "vf_body_cold": 0.75,       # V  @ ~30A, 25°C (p3 source-drain diode curve)
         "vf_body_hot":  0.60,       # V  @ ~30A, 100°C
         "trr":          29e-9,      # s  (p2)
-        "qrr":          113e-9,     # C  (p2) — much higher than SP40N03GNJ
-        "rth_jc":       0.96,       # °C/W (p2) — better, larger package
+        "qrr":          113e-9,     # C  (p2), much higher than SP40N03GNJ
+        "rth_jc":       0.96,       # °C/W (p2), better, larger package
         "pd_max":       130.0,      # W
         "tj_max":       150.0,      # °C
         # Board
@@ -253,7 +253,7 @@ def print_full_report(profile_key: str, i: float, v_bus: float, duty: float,
     eff = p_motor / (p_motor + p_board) * 100 if p_motor > 0 else 0
 
     print("=" * 70)
-    print(f"  4in1 ESC Power Loss Report  —  {p['name']}")
+    print(f"  4in1 ESC Power Loss Report  -  {p['name']}")
     print(f"  AM32 6-Step Trapezoidal  |  NSG2065Q gate driver")
     print("=" * 70)
     print(f"  Battery voltage:      {v_bus:.1f} V")
@@ -395,7 +395,7 @@ def compare_boards(v_bus: float, duty: float, f_pwm: float, comp_pwm: bool,
 
     print()
     print("=" * 78)
-    print("  BOARD COMPARISON  —  20×20 vs 30×30")
+    print("  BOARD COMPARISON  -  20×20 vs 30×30")
     print(f"  {v_bus:.0f}V  {duty*100:.0f}% duty  {f_pwm/1e3:.0f}kHz  "
           f"comp_pwm={'ON' if comp_pwm else 'OFF'}  {n_active} phases")
     print("=" * 78)


### PR DESCRIPTION
Fixes the clean-room verification findings for this repo (style pass, non-KiCad files only).

## Changes
- `hardware/datasheets/COMPONENT_REVIEW.md`: removed all 35 em-dash lines. Headings use colons, prose uses commas or colons, empty table spec cells use a plain hyphen.
- `hardware/tools/esc_thermal.py`: em dashes removed from comments (lines 17, 74, 75) and printed report banners (lines 256, 398, now spaced hyphens).
- `hardware/scripts/v_beta_hygiene_fix.py`: em dashes removed from docstring, comment, and error message (lines 1, 41, 138).
- `hardware/flash_openesc20.sh`: em dash removed from loop-mode echo string (line 179).

## Checked, no changes needed
- No `OpenESC_20X20` slug occurrences in prose or links (only inside .kicad_*/.step files).
- No personal names outside the LICENSE copyright line.
- No en dashes anywhere in the repo.

## Skipped (separate KiCad content pass)
- `hardware/4in1-mini.kicad_pro` line 697: DOC_TAGLINE em dash. Not touched, .kicad_* content edits are out of scope for this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)