### PR TITLE
Rewrite CONTRIBUTING for humans

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.kicad_pcb -text lockable
+*.kicad_sch -text lockable
+*.kicad_pro -text lockable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,51 @@
 # Contributing
 
+## Before you edit a board
+
+KiCad files cannot be merged. If two people edit the same `.kicad_pcb`, one of
+them loses the work.
+
+1. Open an issue describing the change and wait for the maintainer to agree.
+2. Claim the file: `git lfs lock <path>.kicad_pcb`
+3. `git lfs locks` shows who holds what. If a file is held, talk to that person
+   in the issue instead of starting anyway.
+4. After the pull request is merged: `git lfs unlock <path>.kicad_pcb`
+
+A pull request touching a file locked by someone else gets closed, not merged.
+
 ## Setup
 
 ```
 git clone --recursive https://github.com/incutec-hw/OpenESC-20x20.git
 ```
 
-The `--recursive` flag pulls the `libs/KiCad-Library` submodule, which the project lib tables reference for shared parts. Use KiCad 10.
+KiCad 10. The `--recursive` flag pulls `libs/KiCad-Library`, which the project
+library tables reference for shared parts. Edit in KiCad; never text-edit
+`.kicad_sch` or `.kicad_pcb`.
 
-## Workflow
+## Before opening a pull request
 
-- `main` is protected. Work on a feature branch and open a pull request.
-- Edit schematics and the PCB in KiCad only. Never text-edit `.kicad_sch`, `.kicad_pcb`, or other `.kicad_*` files.
-- New shared parts (symbols, footprints, 3D models) go to [incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) via PR there, not into this repo's local libraries.
-- ERC and DRC must be clean before opening a PR:
+- ERC and DRC clean on every board you touched:
 
 ```
 kicad-cli sch erc --exit-code-violations hardware/4in1-mini.kicad_sch
 kicad-cli pcb drc --exit-code-violations hardware/4in1-mini.kicad_pcb
 ```
 
-## Documentation
+- Post before and after board renders in the pull request. A text diff of a
+  PCB is not reviewable.
+- Say what you tested on real hardware, or say that you tested nothing.
 
-Docs state current fact only: no TODOs, no plans, no aspirational content.
+## Parts
+
+New symbols, footprints and 3D models go to
+[incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) by pull
+request there, never into this repo. Prefer LCSC basic parts.
 
 ## Licensing
 
-Contributions are licensed under CERN-OHL-S-2.0, the same license as the project.
+Hardware contributions are licensed CERN-OHL-S-2.0, the same as the project.
+Sign off your commits with `git commit -s` to certify you wrote the work.
 
 ## Questions
 


### PR DESCRIPTION
Leads with the concurrent-edit problem: claim design files with git lfs lock, discuss in an issue first. Adds render-proof and sign-off requirements, drops the internal doc rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)