### PR TITLE
Drop the KiCad-Library submodule: nothing references it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/KiCad-Library"]
-	path = libs/KiCad-Library
-	url = https://github.com/OpenDrone-hw/KiCad-Library.git

--- a/20x20-ESC-QC/fp-lib-table
+++ b/20x20-ESC-QC/fp-lib-table
@@ -1,5 +1,4 @@
 (fp_lib_table
   (version 7)
   (lib (name "ESC-QC")(type "KiCad")(uri "${KIPRJMOD}/ESC-QC.pretty")(options "")(descr "QC fixture footprints (pogo receptacles, contact pads, alignment)"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/20x20-ESC-QC/sym-lib-table
+++ b/20x20-ESC-QC/sym-lib-table
@@ -1,5 +1,4 @@
 (sym_lib_table
   (version 7)
   (lib (name "ESC-QC")(type "KiCad")(uri "${KIPRJMOD}/ESC-QC.kicad_sym")(options "")(descr "QC fixture symbols (pogo pins, test points)"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ the standard 8-pin connector. 6S only, and there is no input TVS.
 | Board | `hardware/4in1-mini.kicad_pcb`, 6 layers, 1.69 mm, outline approx 31.3 x 33.1 mm |
 | QC fixture | `20x20-ESC-QC/`, a separate project. Press-contact fixture, board is a negative of the ESC contact face |
 | Local library | `hardware/components.kicad_sym`, `hardware/4in1ESC.pretty/`. Frozen pre-consolidation libraries: use them, do not add to them |
-| Shared library | [OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library), submodule at `libs/KiCad-Library` |
+| Shared library | [OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library), catalogue only; every library this board uses is local to the repo |
 | Design rules | `hardware/4in1-mini.kicad_dru` |
 | Fab config | `hardware/fabrication-toolkit-options.json` |
 | License | CERN-OHL-S-2.0 |

--- a/hardware/fp-lib-table
+++ b/hardware/fp-lib-table
@@ -1,5 +1,4 @@
 (fp_lib_table
   (version 7)
   (lib (name "4in1ESC")(type "KiCad")(uri "${KIPRJMOD}/4in1ESC.pretty")(options "")(descr ""))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/hardware/sym-lib-table
+++ b/hardware/sym-lib-table
@@ -1,5 +1,4 @@
 (sym_lib_table
   (version 7)
   (lib (name "components")(type "KiCad")(uri "${KIPRJMOD}/components.kicad_sym")(options "")(descr ""))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )


### PR DESCRIPTION
Verified across the design files: zero `Incutec:` symbols or footprints placed, zero 3D paths into `libs/KiCad-Library`. Boards are fully self-contained by the copy-local policy, so the submodule only cost recursive clones and pin maintenance. KiCad-Library remains the catalogue of manufactured parts, referenced by docs, not by designs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)