### PR TITLE
docs: add voltage range to input spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Maintained by [@Just4Stan](https://github.com/Just4Stan).
 | Firmware | AM32 |
 | ESC protocol | DShot, bidirectional |
 | Telemetry | Extended DShot |
-| Input | 2-6S LiPo |
+| Input | 2-6S LiPo (6.0-25.2 V) |
 | BEC | None |
 | MCU | One per motor |
 | MOSFETs | 6 per motor |


### PR DESCRIPTION
Input row now reads 2-6S LiPo (6.0-25.2 V).

🤖 Generated with [Claude Code](https://claude.com/claude-code)