### PR TITLE
AGENTS: 2026-08-21 bench findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,37 @@ Current sensing is **board level, not per channel**: an INA186A3IDCKR at
 30x30 sibling uses two shunts in parallel and reads twice the current at half
 the sensitivity.
 
+**`/CURR` is unusable below full throttle, measured 2026-08-21.** The shunt is
+high side, so both amplifier inputs ride the switching bus, and the
+common-mode feedthrough rectifies to a duty-dependent offset. Against a
+current clamp the chain reads +164% at 15% throttle, hard-fails at 80% (the
+raw ADC count itself collapses from ~680 to ~290 while the clamp holds a
+steady 32 A), and is honest only at 100% throttle where AM32 stops chopping:
+there it reads a clean +11 to +12% gain error. No filter, averaging or
+firmware change can reach it; the fix is a respin that either moves the shunt
+low side or gives the amplifier a matched input network. Until then anything
+consuming `/CURR` (Betaflight OSD current, mAh-drawn battery math) gets
+garbage at flight throttles. Evidence:
+`OpenDrone-Testing/Logs/esc-04-20x20-20260821T150430Z/`.
+
+**Thermal envelope, measured 2026-08-21 on one board.** Continuous 30-34 A
+per channel fan-cooled at a 115 C die; die plateau demonstrated at 26 A, the
+rest of the bracket extrapolated from ramp data. Burst 64 A for 2 s on one
+channel, 112 A board-level for 2.4 s, die still rising 4-6 C/s at step end.
+Destruction at ~40 A sustained: the board fails by SOLDER REFLOW, two FETs
+desoldered (joints past 217 C) while the die read 161 C, so the die
+under-reads the FET joint by roughly 50 C and heat extraction, not silicon,
+is the ceiling. Thermal time constant 4.2-5.3 s. Evidence:
+`OpenDrone-Testing/Logs/esc-18-20x20-20260821T181141Z/` and
+`esc-14-20x20-20260821T154902Z/`.
+
+**As-flashed AM32 config, audited 2026-08-21.** Boards flash with
+`limits.temperature = 255`, so AM32's own thermal foldback never engages and
+nothing on the board protects the FETs; `motor_kv` defaults to the 2808
+preset (decodes 2220 Kv), which caps duty near 0.26 on lower-Kv motors via
+`low_rpm_level`/`high_rpm_level`. Both must be set per product in the
+flashing jig before boards ship.
+
 **There is no input protection.** A clamp diode's 24 V standoff sits below
 the 25.2 V a full 6S pack reaches, so none is fitted on the 2S-6S input.
 


### PR DESCRIPTION
Current-sense common-mode fault (measured, ESC-04), measured thermal envelope (ESC-14/18), and the as-flashed AM32 config facts that gate the first batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)